### PR TITLE
feat: add role user

### DIFF
--- a/src/main/java/edu/eci/cvds/pattens/service/AuthService.java
+++ b/src/main/java/edu/eci/cvds/pattens/service/AuthService.java
@@ -33,6 +33,7 @@ public class AuthService {
                 .withClaim("email", user.getEmail())
                 .withClaim("fullName", user.getFullName())
                 .withClaim("creationDate", user.getCreationDate().toString())
+                .withClaim("role", user.getRole().toString())
                 .sign(Algorithm.HMAC256("secret"));
         return token;
     }


### PR DESCRIPTION
This pull request includes a small change to the `loginUser` method in the `AuthService` class to include the user's role in the generated token.

* [`src/main/java/edu/eci/cvds/pattens/service/AuthService.java`](diffhunk://#diff-5274f8d767e18ee031a1510bfb55ad6a638c3b9dab9e4ee2a04e89f864709834R36): Added a new claim for the user's role in the JWT token generation process.