### PR TITLE
origins permise

### DIFF
--- a/src/main/java/edu/eci/cvds/pattens/config/CorsConfig.java
+++ b/src/main/java/edu/eci/cvds/pattens/config/CorsConfig.java
@@ -13,10 +13,12 @@ public class CorsConfig implements WebMvcConfigurer {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/api/**")
-                        .allowedOrigins("*")
+                registry.addMapping("/api/")
+                        .allowedOrigins("localhost:3000/api/",
+                                "https://cvdstodo-gsesacf6egbuhkh3.centralus-01.azurewebsites.net/api/")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
-                        .allowedHeaders("*");
+                        .allowedHeaders("*")
+                        .allowCredentials(false);
             }
         };
     }


### PR DESCRIPTION
This pull request includes changes to the CORS configuration in the `CorsConfig.java` file to restrict allowed origins and update the CORS policy.

CORS Configuration Updates:

* [`src/main/java/edu/eci/cvds/pattens/config/CorsConfig.java`](diffhunk://#diff-e75afe0447027e07411216d3f0c37cf5ffbe2b1814ef9b474b889decaf1fa849L16-R21): Modified the `addCorsMappings` method to change the CORS mapping from `/api/**` to `/api/`, restrict allowed origins to specific URLs, and disallow credentials.